### PR TITLE
Fix GitHub Pages: replace legacy Vue page with Basira v0.2.0 landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Basira (بصيرة, "insight") is an Arabic-first React Native / Expo app for discovering books. It opens with a short story honouring **Ibn al-Haytham (Alhazen)** — the father of optics — and then lets the reader search for books or scan an ISBN with the camera.
 
+> **GitHub Pages vs the Expo app** — the live site at [`aaljaser.github.io/FinalProject`](https://aaljaser.github.io/FinalProject) serves the root `index.html` as a Basira v0.2.0 landing page with a working Google Books search. ISBN camera scanning is mobile-only (it requires `expo-camera`), so the Pages site links out to the v0.2.0 release and the repo for the full Expo app.
+
 ## Features
 
 - **Real book search** powered by the public [Google Books API](https://developers.google.com/books/docs/v1/using).

--- a/index.html
+++ b/index.html
@@ -1,633 +1,597 @@
-<script type="text/javascript">
-  var gk_isXlsx = false;
-  var gk_xlsxFileLookup = {};
-  var gk_fileData = {};
-  function filledCell(cell) {
-    return cell !== '' && cell != null;
-  }
-  function loadFileData(filename) {
-  if (gk_isXlsx && gk_xlsxFileLookup[filename]) {
-      try {
-          var workbook = XLSX.read(gk_fileData[filename], { type: 'base64' });
-          var firstSheetName = workbook.SheetNames[0];
-          var worksheet = workbook.Sheets[firstSheetName];
-
-          // Convert sheet to JSON to filter blank rows
-          var jsonData = XLSX.utils.sheet_to_json(worksheet, { header: 1, blankrows: false, defval: '' });
-          // Filter out blank rows (rows where all cells are empty, null, or undefined)
-          var filteredData = jsonData.filter(row => row.some(filledCell));
-
-          // Heuristic to find the header row by ignoring rows with fewer filled cells than the next row
-          var headerRowIndex = filteredData.findIndex((row, index) =>
-            row.filter(filledCell).length >= filteredData[index + 1]?.filter(filledCell).length
-          );
-          // Fallback
-          if (headerRowIndex === -1 || headerRowIndex > 25) {
-            headerRowIndex = 0;
-          }
-
-          // Convert filtered JSON back to CSV
-          var csv = XLSX.utils.aoa_to_sheet(filteredData.slice(headerRowIndex)); // Create a new sheet from filtered array of arrays
-          csv = XLSX.utils.sheet_to_csv(csv, { header: 1 });
-          return csv;
-      } catch (e) {
-          console.error(e);
-          return "";
-      }
-  }
-  return gk_fileData[filename] || "";
-  }
-  </script><!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="ar" dir="rtl">
 <head>
 <meta charset="UTF-8">
-<title>البحث عن الكتب</title>
+<title>بصيرة · Basira — اكتشف الكتب على خطى ابن الهيثم</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/5.0.0/normalize.min.css">
-<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic&display=swap" rel="stylesheet">
+<meta name="description" content="بصيرة (Basira) — تطبيق Expo عربي لاكتشاف الكتب عبر بحث Google Books ومسح رمز ISBN بالكاميرا. الإصدار 0.2.0.">
+<meta name="theme-color" content="#2e4a4f">
+<meta property="og:title" content="بصيرة · Basira v0.2.0">
+<meta property="og:description" content="تطبيق عربي لاكتشاف الكتب — بحث حي عبر Google Books ومسح ISBN بالكاميرا.">
+<meta property="og:type" content="website">
+<link rel="icon" href="./assets/favicon.png" type="image/png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Noto+Kufi+Arabic:wght@400;600;700&family=Noto+Sans+Arabic:wght@400;600;700&display=swap" rel="stylesheet">
 <style>
 :root {
---primary-color: hsl(0deg 0% 0% / 0.25);
---secondary-color: rgb(185, 183, 175);
---background-color: white;
---box-shadow-color: rgba(0, 0, 0, 0.1);
---border-radius: 12px;
---transition-duration: 600ms;
---transition-timing-function: cubic-bezier(.3, .7, .4, 1);
+  --bg-top: #2e4a4f;
+  --bg-bottom: #101110;
+  --accent: #3f6b71;
+  --accent-strong: #4e8a92;
+  --text: #ffffff;
+  --muted: #cfd8dc;
+  --muted-2: #9aa6ab;
+  --card: rgba(255, 255, 255, 0.08);
+  --card-strong: rgba(255, 255, 255, 0.12);
+  --border: rgba(255, 255, 255, 0.14);
+  --radius: 14px;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
 }
+
+* { box-sizing: border-box; }
 
 html, body {
-height: 100%;
-margin: 0;
-padding: 0;
-font-family: 'Montserrat Alternates', sans-serif;
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: linear-gradient(180deg, var(--bg-top) 0%, var(--bg-bottom) 100%);
+  color: var(--text);
+  font-family: 'Noto Kufi Arabic', 'Noto Sans Arabic', system-ui, -apple-system, Segoe UI, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-/* Splash Screen Styles */
-#splash-screen {
-position: fixed;
-top: 0;
-left: 0;
-width: 100%;
-height: 100%;
-background: #2e4a4f;
-display: flex;
-flex-direction: column;
-justify-content: center;
-align-items: center;
-z-index: 2000;
-transition: opacity 1s ease;
+a { color: #cfe7ea; text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.shell {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 28px 20px 60px;
 }
 
-#splash-screen.hidden {
-opacity: 0;
-display: none;
+header.brand {
+  text-align: center;
+  padding: 16px 0 8px;
 }
 
-.logo {
-width: 100px;
-height: 100px;
-background: radial-gradient(circle, #ccc 50%, #fff 50%);
-border-radius: 50%;
-position: relative;
-margin-bottom: 20px;
+.brand h1 {
+  font-size: clamp(2.2rem, 5vw, 3rem);
+  margin: 0 0 6px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+.brand .latin {
+  color: var(--muted);
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+.brand .tagline {
+  color: var(--muted);
+  font-size: 1.05rem;
+  margin: 0 auto;
+  max-width: 560px;
 }
 
-.logo::after {
-content: '';
-position: absolute;
-top: 10%;
-right: 10%;
-width: 20px;
-height: 20px;
-background: #2e4a4f;
-border-radius: 50%;
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px;
+  margin-top: 14px;
+}
+.badge {
+  background: var(--card-strong);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+.badge.version {
+  background: var(--accent);
+  color: #fff;
+  border-color: transparent;
+  font-weight: 600;
 }
 
-.credits {
-text-align: center;
-color: #fff;
+/* Search */
+.search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--card-strong);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 10px;
+  margin: 22px auto 6px;
+  max-width: 640px;
+  box-shadow: var(--shadow);
+}
+.search svg.icon { flex-shrink: 0; opacity: 0.85; }
+.search input {
+  flex: 1;
+  background: transparent;
+  border: 0;
+  outline: 0;
+  color: #fff;
+  font: inherit;
+  font-size: 1.05rem;
+  padding: 10px 6px;
+  text-align: right;
+}
+.search input::placeholder { color: var(--muted-2); }
+
+.scan-btn {
+  background: var(--accent);
+  color: #fff;
+  border: 0;
+  border-radius: 10px;
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+.scan-btn:hover { background: var(--accent-strong); }
+.scan-btn:active { transform: translateY(1px); }
+.scan-btn:focus-visible { outline: 2px solid #fff; outline-offset: 2px; }
+
+.search-hint {
+  text-align: center;
+  color: var(--muted-2);
+  font-size: 0.9rem;
+  margin-bottom: 14px;
 }
 
-/* Story Overlay Styles */
-#story-overlay {
-position: fixed;
-top: 0;
-left: 0;
-width: 100%;
-height: 100%;
-background: rgba(0, 0, 0, 0.8);
-display: none;
-flex-direction: column;
-justify-content: center;
-align-items: center;
-text-align: center;
-z-index: 1000;
-overflow-y: auto;
-padding: 20px;
-transition: opacity 1s ease;
+/* States */
+.state {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--muted);
+}
+.state .state-title {
+  font-size: 1.15rem;
+  color: #fff;
+  font-weight: 600;
+  margin: 12px 0 6px;
+}
+.state .state-sub {
+  font-size: 0.95rem;
+  color: var(--muted);
+  max-width: 460px;
+  margin: 0 auto;
+}
+.state svg { opacity: 0.7; }
+
+.spinner {
+  display: inline-block;
+  width: 36px;
+  height: 36px;
+  border: 3px solid rgba(255,255,255,0.25);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 0.9s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* Results */
+.results {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 12px;
+  margin-top: 8px;
+}
+@media (min-width: 720px) {
+  .results { grid-template-columns: 1fr 1fr; }
 }
 
-#story-overlay.active {
-display: flex;
+.book {
+  display: flex;
+  flex-direction: row;
+  gap: 12px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px;
+  text-align: right;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+.book:hover { background: var(--card-strong); }
+.book-cover {
+  width: 72px;
+  height: 108px;
+  border-radius: 8px;
+  background: rgba(255,255,255,0.05);
+  flex-shrink: 0;
+  object-fit: cover;
+  display: block;
+}
+.book-cover.placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted-2);
+  font-size: 0.8rem;
+}
+.book-info { flex: 1; min-width: 0; }
+.book-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #fff;
+  margin: 0 0 4px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.book-author {
+  font-size: 0.9rem;
+  color: var(--muted);
+  margin: 0 0 4px;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.book-meta {
+  font-size: 0.78rem;
+  color: var(--muted-2);
+  margin: 0 0 6px;
+}
+.book-desc {
+  font-size: 0.82rem;
+  color: var(--muted);
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
-#story-overlay.hidden {
-opacity: 0;
-display: none;
+/* Mobile callout */
+.mobile-cta {
+  margin-top: 28px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px 20px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  align-items: center;
+  justify-content: space-between;
 }
+.mobile-cta .cta-text { flex: 1 1 280px; }
+.mobile-cta h3 {
+  margin: 0 0 6px;
+  font-size: 1.1rem;
+  color: #fff;
+}
+.mobile-cta p { margin: 0; color: var(--muted); font-size: 0.92rem; }
+.cta-actions { display: flex; gap: 10px; flex-wrap: wrap; }
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--accent);
+  color: #fff;
+  border: 0;
+  border-radius: 10px;
+  padding: 10px 16px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background 0.15s ease;
+}
+.btn:hover { background: var(--accent-strong); text-decoration: none; }
+.btn.secondary {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: #fff;
+}
+.btn.secondary:hover { background: var(--card-strong); }
 
-#story-text {
-font-size: 1.2em;
-color: #fff;
-max-width: 800px;
-margin: 0 20px;
-font-family: 'Montserrat Alternates', sans-serif;
-direction: rtl;
-line-height: 1.6;
+/* Release notes */
+.release {
+  margin-top: 28px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
 }
+.release h2 {
+  margin: 0 0 10px;
+  font-size: 1.2rem;
+  color: #fff;
+}
+.release ul {
+  margin: 0;
+  padding-inline-start: 20px;
+  color: var(--muted);
+}
+.release li { margin-bottom: 6px; }
+.release li strong { color: #fff; font-weight: 600; }
 
-#continue-btn, #skip-btn {
-margin-top: 20px;
-padding: 10px 20px;
-font-size: 1em;
-background: #007bff;
-border: none;
-color: white;
-cursor: pointer;
-border-radius: 5px;
-font-family: 'Montserrat Alternates', sans-serif;
+/* Heritage note */
+.heritage {
+  margin-top: 28px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.95rem;
+  max-width: 640px;
+  margin-inline: auto;
+  padding: 0 8px;
 }
+.heritage em { color: #fff; font-style: normal; font-weight: 600; }
 
-#continue-btn:hover, #skip-btn:hover {
-background: #0056b3;
+footer.site-footer {
+  margin-top: 36px;
+  text-align: center;
+  color: var(--muted-2);
+  font-size: 0.85rem;
 }
+footer.site-footer a { color: var(--muted); }
 
-#skip-btn {
-position: absolute;
-top: 20px;
-left: 20px;
-background: transparent;
+/* Modal */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.65);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 1000;
 }
+.modal-backdrop.open { display: flex; }
+.modal {
+  background: #1c2c2f;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  max-width: 460px;
+  width: 100%;
+  padding: 22px;
+  text-align: right;
+  box-shadow: var(--shadow);
+}
+.modal h3 { margin: 0 0 10px; color: #fff; }
+.modal p { color: var(--muted); margin: 0 0 16px; }
+.modal .modal-actions { display: flex; gap: 10px; flex-wrap: wrap; justify-content: flex-start; }
 
-/* Main App Styles */
-#main-content {
-display: none;
-height: 100%;
-background: linear-gradient(-45deg, #ee7752, #4e786d, #396474, #101110bc);
-background-size: 400% 400%;
-animation: gradient 6s ease infinite;
-}
-
-#main-content.active {
-display: block;
-}
-
-@keyframes gradient {
-0% { background-position: 0% 50%; }
-50% { background-position: 100% 50%; }
-100% { background-position: 0% 50%; }
-}
-
-.top {
-padding: 10px;
-text-align: center;
-}
-
-svg {
-width: 160px;
-height: 160px;
-display: block;
-margin: 0 auto;
-}
-
-.v {
-text-align: center;
-border-radius: 7px;
-padding: 8px;
-width: 60%;
-max-width: 360px;
-margin: 10px auto;
-display: block;
-border: 1px solid #ccc;
-font-size: 1.32em;
-outline: none;
-}
-
-.v::placeholder {
-color: #999;
-}
-
-.pushable {
-justify-self: center;
-position: relative;
-border: none;
-background: transparent;
-padding: 0;
-cursor: pointer;
-outline-offset: 4px;
-transition: filter 250ms;
-}
-
-.shadow {
-position: absolute;
-top: 0;
-left: 0;
-width: 100%;
-height: 100%;
-border-radius: 12px;
-background: hsl(0deg 0% 0% / 0.25);
-will-change: transform;
-transform: translateY(2px);
-transition: transform 600ms cubic-bezier(.3, .7, .4, 1);
-}
-
-.edge {
-position: absolute;
-top: 0;
-left: 0;
-width: 100%;
-height: 100%;
-border-radius: 12px;
-background: linear-gradient(to left, rgb(121, 121, 123) 0%, rgb(121, 121, 123) 8%, rgb(121, 121, 123) 92%, rgb(121, 121, 123) 100%);
-}
-
-.front {
-display: block;
-position: relative;
-padding: 6px 16px;
-border-radius: 12px;
-font-size: 1.25rem;
-color: white;
-background: rgb(138, 137, 141);
-will-change: transform;
-transform: translateY(-4px);
-transition: transform 600ms cubic-bezier(.3, .7, .4, 1);
-}
-
-.pushable:hover {
-filter: brightness(110%);
-}
-
-.pushable:hover .front {
-transform: translateY(-6px);
-transition: transform 250ms cubic-bezier(.3, .7, .4, 1.5);
-}
-
-.pushable:active .front {
-transform: translateY(-2px);
-transition: transform 34ms;
-}
-
-.pushable:hover .shadow {
-transform: translateY(4px);
-transition: transform 250ms cubic-bezier(.3, .7, .4, 1.5);
-}
-
-.pushable:active .shadow {
-transform: translateY(1px);
-transition: transform 34ms;
-}
-
-.pushable:focus:not(:focus-visible) {
-outline: none;
-}
-
-.search-form {
-margin-top: 20%;
-display: flex;
-flex-direction: column;
-align-items: center;
-}
-
-.search-results {
-display: flex;
-flex-wrap: wrap;
-justify-content: center;
-padding: 20px;
-}
-
-.search-result {
-margin: 10px;
-background-color: gainsboro;
-border-radius: 0.25rem;
-box-shadow: 0 1rem 1rem -0.75rem #dfc8c0;
-padding: 10px;
-width: 300px;
-display: flex;
-align-items: flex-start;
-}
-
-.search-result--thumbnail {
-width: 80px;
-height: auto;
-margin-right: 10px;
-}
-
-.search-result--info {
-flex: 1;
-text-align: right;
-}
-
-.search-result--title {
-font-weight: bold;
-font-size: 1.1rem;
-}
-
-.search-result--authors {
-font-size: 0.9rem;
-color: #555;
-}
-
-.search-result--published {
-font-size: 0.8rem;
-color: #777;
-}
-
-.error {
-color: red;
-text-align: center;
-margin: 20px;
-}
-
-label {
-font-size: 0.9rem;
-font-weight: bold;
-margin-bottom: 5px;
-}
-
-footer {
-margin-top: 20px;
-padding: 10px;
-text-align: center;
-color: #333;
-}
-
-.message, .copyrights {
-font-size: 0.9rem;
-}
-
-@media (max-width: 768px) {
-.v {
-  width: 90%;
-}
-.search-result {
-  width: 80%;
-}
-.search-form {
-  margin-top: 10%;
-}
-#story-text {
-  font-size: 1em;
-}
+@media (max-width: 540px) {
+  .shell { padding: 18px 14px 40px; }
+  .book-cover { width: 64px; height: 96px; }
 }
 </style>
 </head>
 <body>
-<!-- Splash Screen -->
-<div id="splash-screen">
-<div class="logo"></div>
-<div class="credits">
-<p>صنع بواسطة عبدالكريم الجاسر</p>
-<p>حقوق النشر 2019</p>
-</div>
-</div>
+<div class="shell">
+  <header class="brand">
+    <h1>بصيرة</h1>
+    <div class="latin">Basira</div>
+    <p class="tagline">اكتشف الكتب على خطى ابن الهيثم — بحث حي عبر Google Books ومسح رمز ISBN بالكاميرا.</p>
+    <div class="badges">
+      <span class="badge version">الإصدار 0.2.0</span>
+      <span class="badge">Expo · React Native</span>
+      <span class="badge">عربي · RTL</span>
+    </div>
+  </header>
 
-<!-- Story Overlay -->
-<div id="story-overlay">
-<button id="skip-btn" onclick="endStory()">تخطي</button>
-<div id="story-text"></div>
-<button id="continue-btn" onclick="endStory()">ابحث عن كتابك</button>
-</div>
-
-<!-- Main App Content -->
-<div id="main-content">
-<div class="top">
-<svg viewBox="0 0 160 160" width="160" height="160">
-  <circle cx="80" cy="80" r="50" fill="#ccc" />
-  <g transform="matrix(0.866, -0.5, 0.25, 0.433, 80, 80)">
-    <path d="M 0,70 A 65,70 0 0,0 65,0 5,5 0 0,1 75,0 75,70 0 0,1 0,70Z" fill="#FFF">
-      <animateTransform attributeName="transform" type="rotate" from="360 0 0" to="0 0 0" dur="1s" repeatCount="indefinite" />
-    </path>
-  </g>
-  <path d="M 50,0 A 50,50 0 0,0 -50,0Z" transform="matrix(0.866, -0.5, 0.5, 0.866, 80, 80)" fill="#aaa" />
-</svg>
-</div>
-
-<div id="app">
-<main>
-  <form class="search-form" @submit.prevent="search">
-    <label for="search-input">ابحث عن كتاب</label>
-    <input id="search-input" class="v" type="text" v-model.trim="searchTerm" placeholder="⌕ اكتب اسم المؤلف، الكتاب، أو الموضوع...">
-    <button class="pushable">
-      <span class="shadow"></span>
-      <span class="edge"></span>
-      <span class="front">بحث</span>
+  <form class="search" id="search-form" role="search" autocomplete="off">
+    <svg class="icon" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#cfd8dc" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="11" cy="11" r="7"></circle><path d="m21 21-4.3-4.3"></path></svg>
+    <input
+      id="q"
+      name="q"
+      type="search"
+      inputmode="search"
+      placeholder="ابحث عن كتاب أو مؤلف…"
+      aria-label="ابحث عن كتاب أو مؤلف"
+    />
+    <button type="button" class="scan-btn" id="scan-btn" aria-label="مسح رمز ISBN بالكاميرا" title="مسح رمز ISBN (في تطبيق الجوال)">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 5v14"/><path d="M7 5v14"/><path d="M11 5v14"/><path d="M15 5v14"/><path d="M19 5v14"/></svg>
     </button>
   </form>
+  <div class="search-hint">جرّب: <em>ابن الهيثم</em>، <em>طه حسين</em>، <em>Harry Potter</em></div>
 
-  <div class="search-results" v-if="searchResults.length">
-    <div class="search-result" v-for="book in searchResults" :key="book.id">
-      <img class="search-result--thumbnail" :src="'http://books.google.com/books/content?id=' + book.id + '&printsec=frontcover&img=1&zoom=1&source=gbs_api'" alt="غلاف الكتاب">
-      <div class="search-result--info">
-        <div class="search-result--title">{{ book.volumeInfo.title }}</div>
-        <div v-if="book.volumeInfo.authors" class="search-result--authors">
-          بقلم {{ bookAuthors(book) }}
-        </div>
-        <div v-if="book.volumeInfo.publishedDate" class="search-result--published">
-          نُشر في {{ book.volumeInfo.publishedDate }}
-        </div>
-      </div>
+  <section id="results-area" aria-live="polite">
+    <div class="state" id="state-idle">
+      <svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.7)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+      <div class="state-title">ابدأ بالبحث</div>
+      <div class="state-sub">اكتب اسم كتاب أو مؤلف، أو امسح رمز ISBN لاستكشاف العناوين.</div>
     </div>
-  </div>
-  <p v-if="errorMessage" class="error">{{ errorMessage }}</p>
-</main>
+  </section>
+
+  <aside class="mobile-cta" aria-labelledby="cta-heading">
+    <div class="cta-text">
+      <h3 id="cta-heading">📷 مسح رمز ISBN يحتاج تطبيق الجوال</h3>
+      <p>مسح الرمز الشريطي بالكاميرا متاح في تطبيق Expo على iOS وأندرويد. حمّل الإصدار <strong>v0.2.0</strong> من صفحة الإصدارات أو شغّل التطبيق محليًا عبر Expo Go.</p>
+    </div>
+    <div class="cta-actions">
+      <a class="btn" href="https://github.com/aaljaser/FinalProject/releases/tag/v0.2.0" target="_blank" rel="noopener">صفحة الإصدار v0.2.0</a>
+      <a class="btn secondary" href="https://github.com/aaljaser/FinalProject" target="_blank" rel="noopener">المستودع على GitHub</a>
+    </div>
+  </aside>
+
+  <section class="release" aria-labelledby="release-heading">
+    <h2 id="release-heading">ما الجديد في v0.2.0</h2>
+    <ul>
+      <li><strong>تسمية جديدة:</strong> أصبح اسم التطبيق <em>بصيرة (Basira)</em> ليعكس تراث ابن الهيثم في علم البصريات.</li>
+      <li><strong>بحث حقيقي:</strong> بحث حي عبر Google Books مع حالات تحميل وفراغ وخطأ، وروابط أغلفة آمنة (HTTPS).</li>
+      <li><strong>مسح ISBN بالكاميرا:</strong> شاشة مسح جديدة عبر <code>expo-camera</code> مع إدارة كاملة لإذن الكاميرا.</li>
+      <li><strong>تلميع عربي:</strong> نصوص عربية شاملة ومحاذاة RTL وبطاقات نتائج معاد تصميمها.</li>
+    </ul>
+  </section>
+
+  <p class="heritage">
+    سُمّي التطبيق <em>بصيرة</em> تكريمًا لـ <strong>الحسن بن الهيثم</strong> (965–1040م) — أبو البصريات وأحد روّاد المنهج العلمي.
+  </p>
+
+  <footer class="site-footer">
+    <p>صنع بواسطة <strong>عبدالكريم الجاسر</strong> · <a href="https://github.com/aaljaser/FinalProject" target="_blank" rel="noopener">المصدر على GitHub</a></p>
+  </footer>
 </div>
 
-<footer>
-<p class="message">صنع بواسطة <span class="name">عبدالكريم الجاسر</span></p>
-<p class="copyrights">حقوق النشر 2019</p>
-</footer>
+<div class="modal-backdrop" id="scan-modal" role="dialog" aria-modal="true" aria-labelledby="scan-modal-title">
+  <div class="modal">
+    <h3 id="scan-modal-title">📷 مسح رمز ISBN</h3>
+    <p>هذه الميزة متاحة في تطبيق الجوال (Expo) عبر كاميرا الجهاز. للاستخدام السريع، اكتب رقم ISBN في خانة البحث أعلاه أو حمّل التطبيق من صفحة الإصدار.</p>
+    <div class="modal-actions">
+      <a class="btn" href="https://github.com/aaljaser/FinalProject/releases/tag/v0.2.0" target="_blank" rel="noopener">صفحة الإصدار v0.2.0</a>
+      <button class="btn secondary" type="button" id="scan-close">إغلاق</button>
+    </div>
+  </div>
 </div>
 
 <script>
-// Story Logic
-console.log('بدء تهيئة الصفحة...');
-const storyText = [
-"يُعدّ الحسن بن الهيثم (965-1040م)، المعروف في الغرب باسم 'Alhazen'، أحد أعظم العلماء في التاريخ، ورائدًا في علم البصريات والمنهج العلمي.",
-"وُلد في البصرة وأمضى حياته في بغداد والقاهرة، حيث أنتج إسهامات غيرت مسار العلوم.",
-"يُشار إليه غالبًا بـ'أبو البصريات' بفضل كتابه الشهير 'كتاب المناظر'، الذي وضع أسس علم البصريات الحديث.",
-"في 'كتاب المناظر'، أثبت ابن الهيثم أن الضوء يسير في خطوط مستقيمة، وشرح كيفية انعكاسه وانكساره.",
-"كما قدم تفسيرًا علميًا للرؤية، مؤكدًا أن العين تتلقى الضوء من الأشياء، وليس العكس كما كان شائعًا في عصره.",
-"هذه الفكرة مهدت لاختراع العدسات والكاميرا المظلمة.",
-"كان ابن الهيثم رائدًا في استخدام التجربة والملاحظة للوصول إلى الحقائق، مما جعله رمزًا للمنهج العلمي.",
-"قوله الشهير: 'من طلب الحقيقة فليبدأ بالشك' يعكس نهجه النقدي.",
-"قدم إسهامات في الهندسة، حيث حلّ مشكلة تُعرف اليوم بـ'مسألة ابن الهيثم'، وساهم في تحسين فهمنا للحركة السماوية.",
-"عند مقارنة ابن الهيثم بعلماء الغرب (باستثناء نيكولا تيسلا)، نجد أوجه تشابه واختلاف مع شخصيات مثل غاليليو غاليلي وإسحاق نيوتن.",
-"يُعتبر غاليليو من رواد المنهج العلمي في أوروبا، لكن ابن الهيثم سبقه بقرون في الاعتماد على التجربة.",
-"بينما ركز غاليليو على الفلك وتحسين التلسكوب، كان تركيز ابن الهيثم على البصريات أكثر شمولية، حيث وضع أسسًا نظرية وعملية استفاد منها لاحقًا علماء مثل غاليليو نفسه.",
-"نيوتن طوّر قوانين الحركة والبصريات، لكن كتاب المناظر لابن الهيثم كان مرجعًا أساسيًا لأعمال نيوتن في دراسة الضوء.",
-"فكرة تحليل الضوء إلى ألوان الطيف التي اشتهر بها نيوتن استلهمت جزئيًا من أفكار ابن الهيثم حول انكسار الضوء.",
-"كيبلر طوّر قوانين حركة الكواكب وأسهم في البصريات، لكنه استفاد بشكل مباشر من أعمال ابن الهيثم في فهم آليات الرؤية وانكسار الضوء، مما ساعده في تطوير نظرياته حول العدسات.",
-"بينما حظي علماء الغرب مثل نيوتن وغاليليو بتقدير واسع في عصر النهضة الأوروبية، كان تأثير ابن الهيثم أقل شهرة في الغرب حتى تُرجم كتابه 'المناظر' في القرن الثالث عشر.",
-"هذا الكتاب ألهم علماء النهضة وأثر في تطور العلم الأوروبي.",
-"ما يميز ابن الهيثم هو قدرته على دمج الفلسفة والرياضيات والتجربة في وقت مبكر جدًا، مما جعله سابقًا لعصره.",
-"ابن الهيثم ليس مجرد عالم إسلامي، بل شخصية عالمية وضعت حجر الأساس لعلوم البصريات والمنهج العلمي.",
-"مقارنة بعلماء الغرب، نجد أنه لم يكن مجرد سابق لهم، بل كان مصدر إلهام لأعمالهم.",
-"إرثه يذكّرنا بأهمية التواصل العلمي عبر الحضارات، حيث شكّل أفكاره جسرًا بين العصور الوسطى والحداثة.",
-"الآن، ابحث عن كتابك واكتشف قصص المعرفة."
-];
+(function () {
+  'use strict';
 
-const splashScreen = document.getElementById('splash-screen');
-const storyOverlay = document.getElementById('story-overlay');
-const storyElement = document.getElementById('story-text');
-const continueButton = document.getElementById('continue-btn');
-const mainContent = document.getElementById('main-content');
+  var API = 'https://www.googleapis.com/books/v1/volumes';
+  var input = document.getElementById('q');
+  var form = document.getElementById('search-form');
+  var resultsArea = document.getElementById('results-area');
+  var scanBtn = document.getElementById('scan-btn');
+  var scanModal = document.getElementById('scan-modal');
+  var scanClose = document.getElementById('scan-close');
 
-async function typeStory() {
-try {
-  console.log('جارٍ كتابة القصة...');
-  storyOverlay.classList.add('active');
-  for (let line of storyText) {
-    await typeLine(line);
-    await wait(1500);
-  }
-  continueButton.style.display = 'block';
-  console.log('اكتملت القصة، إظهار زر المتابعة');
-} catch (error) {
-  console.error('خطأ في القصة:', error);
-  endStory();
-}
-}
+  var debounceTimer = null;
+  var inflight = null;
 
-async function typeLine(text) {
-storyElement.textContent = '';
-for (let char of text) {
-  storyElement.textContent += char;
-  await wait(30);
-}
-}
-
-function wait(ms) {
-return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-function endStory() {
-console.log('إنهاء القصة، إظهار التطبيق');
-if (storyOverlay) {
-  storyOverlay.classList.add('hidden');
-  setTimeout(() => {
-    storyOverlay.style.display = 'none';
-    mainContent.classList.add('active');
-  }, 1000);
-} else {
-  console.warn('غطاء القصة غير موجود، إظهار التطبيق');
-  mainContent.classList.add('active');
-}
-}
-
-// إخفاء شاشة التحميل وبدء القصة
-window.addEventListener('load', () => {
-console.log('تم تحميل الصفحة');
-setTimeout(() => {
-  if (splashScreen) {
-    splashScreen.classList.add('hidden');
-    setTimeout(() => {
-      splashScreen.style.display = 'none';
-      if (storyElement && storyOverlay && continueButton) {
-        typeStory();
-      } else {
-        console.error('عناصر القصة مفقودة، إظهار التطبيق');
-        endStory();
-      }
-    }, 1000);
-  } else {
-    console.warn('شاشة التحميل غير موجودة، بدء القصة');
-    typeStory();
-  }
-}, 3000); // عرض شاشة التحميل لمدة 3 ثوانٍ
-});
-
-// تحميل المكتبات وتهيئة Vue
-function loadScripts() {
-const scripts = [
-  'https://cdnjs.cloudflare.com/ajax/libs/vue/2.2.4/vue.js',
-  'https://cdnjs.cloudflare.com/ajax/libs/axios/0.17.1/axios.js',
-  'https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.17.21/lodash.min.js'
-];
-scripts.forEach(src => {
-  const script = document.createElement('script');
-  script.src = src;
-  script.async = true;
-  script.onerror = () => {
-    console.error(`فشل تحميل ${src}`);
-    endStory(); // إظهار التطبيق إذا فشل تحميل المكتبات
-  };
-  document.head.appendChild(script);
-});
-}
-
-function initVue() {
-try {
-  console.log('جارٍ تهيئة Vue...');
-  new Vue({
-    el: '#app',
-    data() {
-      return {
-        searchTerm: '',
-        searchResults: [],
-        isLoading: false,
-        errorMessage: ''
-      };
-    },
-    methods: {
-      search: _.debounce(function() {
-        if (!this.searchTerm) {
-          this.searchResults = [];
-          this.errorMessage = '';
-          return;
-        }
-        this.isLoading = true;
-        this.errorMessage = '';
-        axios.get(`https://www.googleapis.com/books/v1/volumes?q=${encodeURIComponent(this.searchTerm)}`)
-          .then(response => {
-            this.searchResults = response.data.items || [];
-          })
-          .catch(e => {
-            this.errorMessage = 'حدث خطأ أثناء جلب البيانات.';
-            console.error('خطأ في البحث:', e);
-          })
-          .finally(() => {
-            this.isLoading = false;
-          });
-      }, 300),
-      bookAuthors(book) {
-        let authors = book.volumeInfo.authors || [];
-        if (authors.length < 3) {
-          return authors.join('، ');
-        } else {
-          return authors.slice(0, 2).join('، ') + ' وآخرون';
-        }
-      }
-    }
+  form.addEventListener('submit', function (e) { e.preventDefault(); runSearch(input.value); });
+  input.addEventListener('input', function () {
+    var q = input.value;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(function () { runSearch(q); }, 350);
   });
-  console.log('تم تهيئة Vue بنجاح');
-} catch (error) {
-  console.error('خطأ في تهيئة Vue:', error);
-  endStory();
-}
-}
 
-// تحميل المكتبات وتهيئة Vue
-loadScripts();
-setTimeout(() => {
-if (window.Vue && window.axios && window._) {
-  initVue();
-} else {
-  console.error('فشل تحميل المكتبات، إظهار التطبيق بدون Vue');
-  endStory();
-}
-}, 2000);
+  scanBtn.addEventListener('click', function () { scanModal.classList.add('open'); });
+  scanClose.addEventListener('click', function () { scanModal.classList.remove('open'); });
+  scanModal.addEventListener('click', function (e) { if (e.target === scanModal) scanModal.classList.remove('open'); });
+  document.addEventListener('keydown', function (e) { if (e.key === 'Escape') scanModal.classList.remove('open'); });
+
+  function runSearch(raw) {
+    var q = (raw || '').trim();
+    if (!q) { renderIdle(); return; }
+    if (inflight && inflight.abort) { try { inflight.abort(); } catch (_) {} }
+    renderLoading();
+    var controller = ('AbortController' in window) ? new AbortController() : null;
+    inflight = controller;
+    var url = API + '?q=' + encodeURIComponent(q) + '&maxResults=20&printType=books';
+    fetch(url, controller ? { signal: controller.signal } : undefined)
+      .then(function (res) {
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+      })
+      .then(function (data) {
+        var items = (data && data.items) || [];
+        if (items.length === 0) { renderEmpty(); return; }
+        renderResults(items.map(mapVolume));
+      })
+      .catch(function (err) {
+        if (err && err.name === 'AbortError') return;
+        renderError();
+      });
+  }
+
+  function mapVolume(v) {
+    var info = v.volumeInfo || {};
+    var cover = (info.imageLinks && (info.imageLinks.thumbnail || info.imageLinks.smallThumbnail)) || '';
+    return {
+      id: v.id,
+      title: info.title || 'بدون عنوان',
+      authors: info.authors || [],
+      cover: cover ? cover.replace(/^http:\/\//i, 'https://') : '',
+      year: pickYear(info.publishedDate),
+      description: info.description || '',
+      infoLink: info.infoLink || ''
+    };
+  }
+
+  function pickYear(d) {
+    if (!d) return '';
+    var m = String(d).match(/^(\d{4})/);
+    return m ? m[1] : d;
+  }
+
+  function escapeHtml(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function renderIdle() {
+    resultsArea.innerHTML =
+      '<div class="state">' +
+        '<svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.7)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>' +
+        '<div class="state-title">ابدأ بالبحث</div>' +
+        '<div class="state-sub">اكتب اسم كتاب أو مؤلف، أو امسح رمز ISBN لاستكشاف العناوين.</div>' +
+      '</div>';
+  }
+
+  function renderLoading() {
+    resultsArea.innerHTML =
+      '<div class="state">' +
+        '<div class="spinner" role="status" aria-label="جارٍ البحث"></div>' +
+        '<div class="state-title">جارٍ البحث…</div>' +
+      '</div>';
+  }
+
+  function renderError() {
+    resultsArea.innerHTML =
+      '<div class="state">' +
+        '<svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.7)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12.55a11 11 0 0 1 14 0"/><path d="M1.42 9a16 16 0 0 1 21.16 0"/><path d="M8.53 16.11a6 6 0 0 1 6.95 0"/><line x1="12" y1="20" x2="12.01" y2="20"/></svg>' +
+        '<div class="state-title">تعذّر الاتصال</div>' +
+        '<div class="state-sub">يرجى التحقق من الاتصال بالإنترنت والمحاولة مرة أخرى.</div>' +
+      '</div>';
+  }
+
+  function renderEmpty() {
+    resultsArea.innerHTML =
+      '<div class="state">' +
+        '<svg width="56" height="56" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.7)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/><line x1="3" y1="3" x2="21" y2="21"/></svg>' +
+        '<div class="state-title">لا توجد نتائج</div>' +
+        '<div class="state-sub">جرّب كلمات بحث مختلفة، أو تأكد من صحة رمز ISBN.</div>' +
+      '</div>';
+  }
+
+  function renderResults(books) {
+    var html = '<div class="results">';
+    for (var i = 0; i < books.length; i++) {
+      var b = books[i];
+      var authors = b.authors.length ? b.authors.join('، ') : 'مؤلف غير معروف';
+      var coverHtml = b.cover
+        ? '<img class="book-cover" src="' + escapeHtml(b.cover) + '" alt="غلاف ' + escapeHtml(b.title) + '" loading="lazy" referrerpolicy="no-referrer" onerror="this.outerHTML=\'<div class=&quot;book-cover placeholder&quot;>بدون غلاف</div>\'">'
+        : '<div class="book-cover placeholder">بدون غلاف</div>';
+      var open = b.infoLink
+        ? 'onclick="window.open(' + JSON.stringify(b.infoLink) + ', \'_blank\', \'noopener\')" style="cursor:pointer"'
+        : '';
+      html +=
+        '<article class="book" ' + open + '>' +
+          coverHtml +
+          '<div class="book-info">' +
+            '<h3 class="book-title">' + escapeHtml(b.title) + '</h3>' +
+            '<div class="book-author">بقلم ' + escapeHtml(authors) + '</div>' +
+            (b.year ? '<div class="book-meta">سنة النشر: ' + escapeHtml(b.year) + '</div>' : '') +
+            (b.description ? '<p class="book-desc">' + escapeHtml(b.description) + '</p>' : '') +
+          '</div>' +
+        '</article>';
+    }
+    html += '</div>';
+    resultsArea.innerHTML = html;
+  }
+})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

GitHub Pages still served the old Ibn al-Haytham / Vue splash+story page even after Basira v0.2.0 was merged. Root cause: Pages serves the repo's root `index.html` (a standalone static page), which was untouched by the v0.2.0 PR — that PR only updated the Expo app. This change rewrites the static page to reflect Basira v0.2.0.

- Replace the legacy Vue/`xlsx` shim `index.html` with a polished Arabic-first (RTL) Basira landing page that matches the Expo `HomeScreen` palette (`#2e4a4f → #101110`), Arabic copy, and result-card layout.
- Live book search remains functional via Google Books REST (`https://www.googleapis.com/books/v1/volumes`) with debounced input and idle / loading / empty / error states mirroring the mobile screens.
- ISBN camera scan is surfaced as a clear callout + modal that links to the v0.2.0 release and the repo (camera scanning is mobile-only via `expo-camera`).
- Adds a v0.2.0 release-notes section and a short Ibn al-Haytham heritage line.
- Adds a short note in `README.md` clarifying GitHub Pages vs the Expo app.

## Files changed

- `index.html` — full rewrite (legacy Vue page → Basira v0.2.0 landing + Google Books search)
- `README.md` — adds a one-paragraph note about the Pages site vs the Expo app

## Testing

- [x] `npm test` (no-op per package.json)
- [x] `npm run build` (no-op per package.json)
- [x] Inline JS parses (`new Function`) — 6,213 chars, OK
- [x] Sanity checks: `lang="ar"`, `dir="rtl"`, version `0.2.0`, "بصيرة", and `googleapis.com/books` all present
- [ ] Manual: open the deployed Pages URL and verify search returns covers/titles for "ابن الهيثم" and "Harry Potter" (will run after Pages redeploys)

## Limitations

- Camera ISBN scanning cannot be done in a static GitHub Pages page — the Expo app uses `expo-camera`, which requires the native runtime. The Pages site instead presents a styled callout + modal that points to the v0.2.0 release; users on a phone tap the release link to install the Expo app.
- This PR doesn't change Pages settings (source branch / folder). If the repo's Pages source is something other than `master` / root, the deploy may need a one-time settings adjustment outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)